### PR TITLE
Fix duplicate .html filename in exported data

### DIFF
--- a/confluence2wikijs.js
+++ b/confluence2wikijs.js
@@ -25,7 +25,7 @@ fs.readdir(directoryPath, function (err, files) {
                 page_data = "<!--\ntitle: " + page_title + "\n-->"
                 page_data = page_data + parsedHtml.querySelector("#main-content").innerHTML;
 
-                fs.writeFileSync(path.join(outDirectoryPath, file + ".html"), page_data)
+                fs.writeFileSync(path.join(outDirectoryPath, file), page_data)
             });
         }
     });


### PR DESCRIPTION
Hi am currently testing this nice script and realised that all exported files have a duplicate ".html" in their filename.